### PR TITLE
Address missing mruby.h error and fix example code imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ For usage examples and documentation, please see the
 [go-mruby GoDoc](http://godoc.org/github.com/mitchellh/go-mruby), which
 we keep up to date and full of examples.
 
-For a quick taste of what using go-mruby looks like, though, we provide
-an example below:
+Include the generated `libmruby.a` from the above installation in the working
+directory and import go-mruby. For a quick taste of what using go-mruby looks
+like, though, we provide an example below:
 
 ```go
 package main


### PR DESCRIPTION
When attempting to use mruby-go using the example code the following error is generated:

```
./gomruby.h:10:10: fatal error: 'mruby.h' file not found
#include <mruby.h>
         ^
1 error generated.
```

Including the `libmruby.a` library in the current working directory seemed to resolve this issue.
