### PR TITLE
Fixes cgo ptr issues with Go 1.6

### DIFF
--- a/func.go
+++ b/func.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 //export go_mrb_func_call
-func go_mrb_func_call(s *C.mrb_state, v *C.mrb_value, c_exc *C.mrb_value) *C.mrb_value {
+func go_mrb_func_call(s *C.mrb_state, v *C.mrb_value, c_exc *C.mrb_value) C.mrb_value {
 	// Lookup the classes that we've registered methods for in this state
 	classTable := stateMethodTable[s]
 	if classTable == nil {
@@ -56,9 +56,10 @@ func go_mrb_func_call(s *C.mrb_state, v *C.mrb_value, c_exc *C.mrb_value) *C.mrb
 	// TODO(mitchellh): reuse the Mrb instead of allocating every time
 	mrb := &Mrb{s}
 	result, exc := f(mrb, newValue(s, *v))
+
 	if exc != nil {
 		*c_exc = exc.MrbValue(mrb).value
-		return &mrb.NilValue().value
+		return mrb.NilValue().value
 	}
 
 	// If the result was a Go nil, convert it to a Ruby nil
@@ -66,7 +67,7 @@ func go_mrb_func_call(s *C.mrb_state, v *C.mrb_value, c_exc *C.mrb_value) *C.mrb
 		result = mrb.NilValue()
 	}
 
-	return &result.MrbValue(mrb).value
+	return result.MrbValue(mrb).value
 }
 
 func insertMethod(s *C.mrb_state, c *C.struct_RClass, n string, f Func) {

--- a/gomruby.h
+++ b/gomruby.h
@@ -24,7 +24,7 @@
 //-------------------------------------------------------------------
 // This is declard in func.go and is a way for us to call back into
 // Go to execute a method.
-extern mrb_value *go_mrb_func_call(mrb_state*, mrb_value*, mrb_value*);
+extern mrb_value go_mrb_func_call(mrb_state*, mrb_value*, mrb_value*);
 
 // This calls into Go with a similar signature to mrb_func_t. We have to
 // change it slightly because cgo can't handle the union type of mrb_value,
@@ -32,8 +32,7 @@ extern mrb_value *go_mrb_func_call(mrb_state*, mrb_value*, mrb_value*);
 // pointer to work around Go's confusion with unions.
 static inline mrb_value _go_mrb_func_call(mrb_state *s, mrb_value self) {
     mrb_value exc = mrb_nil_value();
-    mrb_value result = *go_mrb_func_call(s, &self, &exc);
-
+    mrb_value result = go_mrb_func_call(s, &self, &exc);
     // We raise if we got an exception. We have to raise from here and
     // not from within Go because it messes with Go's calling conventions,
     // resulting in a broken stack.


### PR DESCRIPTION
Go 1.6 introduces tighter rules around C / Go pointer passing.

For reference, `go test` on master fails with the following error:
```
> go test

--- FAIL: TestClassDefineClassMethod (0.01s)
panic: runtime error: cgo result has Go pointer [recovered]
	panic: runtime error: cgo result has Go pointer

goroutine 21 [running]:
panic(0x5f4700, 0xc8200724b0)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
testing.tRunner.func1(0xc8200ac090)
	/usr/local/go/src/testing/testing.go:467 +0x192
panic(0x5f4700, 0xc8200724b0)
	/usr/local/go/src/runtime/panic.go:426 +0x4e9
github.com/mikesimons/go-mruby._cgoexpwrap_dc4ead15b2b9_go_mrb_func_call.func1(0xc820049cf8)
	??:0 +0x3a
github.com/mikesimons/go-mruby._cgoexpwrap_dc4ead15b2b9_go_mrb_func_call(0x1f1ed80, 0x7ffd2f5cccf0, 0x7ffd2f5ccd00, 0xc82008a0c0)
	??:0 +0x79
github.com/mikesimons/go-mruby._Cfunc__go_mrb_load_string(0x1f1ed80, 0x1f538e0, 0x0, 0x0)
	??:0 +0x4f
github.com/mikesimons/go-mruby.(*Mrb).LoadString(0xc820088038, 0x62e710, 0x9, 0x0, 0x0, 0x0)
	/home/mike/go/src/github.com/mikesimons/go-mruby/mruby.go:159 +0x13b
github.com/mikesimons/go-mruby.TestClassDefineClassMethod(0xc8200ac090)
	/home/mike/go/src/github.com/mikesimons/go-mruby/class_test.go:13 +0x10d
testing.tRunner(0xc8200ac090, 0x947858)
	/usr/local/go/src/testing/testing.go:473 +0x98
created by testing.RunTests
	/usr/local/go/src/testing/testing.go:582 +0x892
exit status 2
FAIL	github.com/mikesimons/go-mruby	0.032s
```

Since the first thing `_go_mrb_func_call` does is de-reference the pointer returned from `go_mrb_func_call` this seemed like an obvious solution.

Works as far as I can tell.