### PR TITLE
Implements Mrb.ClearException

### DIFF
--- a/mruby.go
+++ b/mruby.go
@@ -31,6 +31,13 @@ func NewMrb() *Mrb {
 	}
 }
 
+// Clears the last exception from mruby state to enable further use of the VM.
+// Without calling this function after an exception is raised, all go-mruby
+// execution paths will continue to return an error.
+func (m *Mrb) ClearException() {
+	m.state.exc = nil
+}
+
 // Restores the arena index so the objects between the save and this point
 // can be garbage collected in the future.
 //

--- a/mruby_test.go
+++ b/mruby_test.go
@@ -11,6 +11,29 @@ func TestNewMrb(t *testing.T) {
 	mrb.Close()
 }
 
+func TestMrbClearException(t *testing.T) {
+	mrb := NewMrb()
+	defer mrb.Close()
+
+	mrb.LoadString(`raise "An exception"`)
+
+	_, err := mrb.LoadString(`"test"`)
+	if err == nil {
+		t.Fatal("exception expected")
+	}
+
+	mrb.ClearException()
+
+	value, err := mrb.LoadString(`"test"`)
+	if err != nil {
+		t.Fatal("exception should have been cleared")
+	}
+
+	if value.String() != "test" {
+		t.Fatal("bad test value returned")
+	}
+}
+
 func TestMrbArena(t *testing.T) {
 	mrb := NewMrb()
 	defer mrb.Close()


### PR DESCRIPTION
Mruby will set `state.exc` to the last exception that occurred but this field is never cleared by go-mruby, nor is there a way for calling code to do so.

Since all codepaths check this field after executing ruby code to determine if there was an error, all attempts to run code in a VM after an exception occurs will result in the same exception.

The idiomatic mruby way of handling exceptions seems to be to clear `state.exc` and either carry on or invoke `backtrace` and such on the stored exception.

This fix just exposes a way to clear the field so that inspection of the exception object can occur (for backtrace and such) or it can simply be ignored.