### PR TITLE
Fixes nil type handling for array / hash

### DIFF
--- a/array.go
+++ b/array.go
@@ -26,7 +26,7 @@ func (v *Array) Get(idx int) (*MrbValue, error) {
 	}
 
 	val := newValue(v.state, result)
-	if val.Type() == TypeFalse {
+	if val.Type() == TypeNil {
 		val = nil
 	}
 

--- a/array_test.go
+++ b/array_test.go
@@ -8,7 +8,7 @@ func TestArray(t *testing.T) {
 	mrb := NewMrb()
 	defer mrb.Close()
 
-	value, err := mrb.LoadString(`["foo", "bar", "baz"]`)
+	value, err := mrb.LoadString(`["foo", "bar", "baz", false]`)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -16,7 +16,7 @@ func TestArray(t *testing.T) {
 	v := value.Array()
 
 	// Len
-	if n := v.Len(); n != 3 {
+	if n := v.Len(); n != 4 {
 		t.Fatalf("bad: %d", n)
 	}
 
@@ -26,6 +26,18 @@ func TestArray(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if value.String() != "bar" {
+		t.Fatalf("bad: %s", value)
+	}
+
+	// Get bool
+	value, err = v.Get(3)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if valType := value.Type(); valType != TypeFalse {
+		t.Fatalf("bad type: %s", valType)
+	}
+	if value.String() != "false" {
 		t.Fatalf("bad: %s", value)
 	}
 }

--- a/gomruby.h
+++ b/gomruby.h
@@ -175,4 +175,8 @@ static inline enum mrb_vtype _go_mrb_type(mrb_value o) {
     return mrb_type(o);
 }
 
+static inline mrb_bool _go_mrb_nil_p(mrb_value o) {
+    return mrb_nil_p(o);
+}
+
 #endif

--- a/hash.go
+++ b/hash.go
@@ -20,7 +20,7 @@ func (h *Hash) Delete(key Value) (*MrbValue, error) {
 	}
 
 	val := newValue(h.state, result)
-	if val.Type() == TypeFalse {
+	if val.Type() == TypeNil {
 		val = nil
 	}
 

--- a/hash_test.go
+++ b/hash_test.go
@@ -8,7 +8,7 @@ func TestHash(t *testing.T) {
 	mrb := NewMrb()
 	defer mrb.Close()
 
-	value, err := mrb.LoadString(`{"foo" => "bar"}`)
+	value, err := mrb.LoadString(`{"foo" => "bar", "baz" => false}`)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -21,6 +21,18 @@ func TestHash(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if value.String() != "bar" {
+		t.Fatalf("bad: %s", value)
+	}
+
+	// Get false type
+	value, err = h.Get(String("baz"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if valType := value.Type(); valType != TypeFalse {
+		t.Fatalf("bad type: %s", valType)
+	}
+	if value.String() != "false" {
 		t.Fatalf("bad: %s", value)
 	}
 
@@ -45,7 +57,7 @@ func TestHash(t *testing.T) {
 	if value.Type() != TypeArray {
 		t.Fatalf("bad: %s", value.Type())
 	}
-	if value.String() != `["foo"]` {
+	if value.String() != `["foo", "baz"]` {
 		t.Fatalf("bad: %s", value)
 	}
 
@@ -62,7 +74,7 @@ func TestHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if value.String() != `[]` {
+	if value.String() != `["baz"]` {
 		t.Fatalf("bad: %s", value)
 	}
 

--- a/value.go
+++ b/value.go
@@ -35,30 +35,31 @@ type MrbValue struct {
 type ValueType uint32
 
 const (
-	TypeFalse ValueType = iota
-	TypeFree
-	TypeTrue
-	TypeFixnum
-	TypeSymbol
-	TypeUndef
-	TypeFloat
-	TypeCptr
-	TypeObject
-	TypeClass
-	TypeModule
-	TypeIClass
-	TypeSClass
-	TypeProc
-	TypeArray
-	TypeHash
-	TypeString
-	TypeRange
-	TypeException
-	TypeFile
-	TypeEnv
-	TypeData
-	TypeFiber
-	TypeMaxDefine
+	TypeFalse     ValueType = iota // 0
+	TypeFree                       // 1
+	TypeTrue                       // 2
+	TypeFixnum                     // 3
+	TypeSymbol                     // 4
+	TypeUndef                      // 5
+	TypeFloat                      // 6
+	TypeCptr                       // 7
+	TypeObject                     // 8
+	TypeClass                      // 9
+	TypeModule                     // 10
+	TypeIClass                     // 11
+	TypeSClass                     // 12
+	TypeProc                       // 13
+	TypeArray                      // 14
+	TypeHash                       // 15
+	TypeString                     // 16
+	TypeRange                      // 17
+	TypeException                  // 18
+	TypeFile                       // 19
+	TypeEnv                        // 20
+	TypeData                       // 21
+	TypeFiber                      // 22
+	TypeMaxDefine                  // 23
+	TypeNil       ValueType = 0xffffffff
 )
 
 func init() {
@@ -155,6 +156,10 @@ func (v *MrbValue) SetProcTargetClass(c *Class) {
 }
 
 func (v *MrbValue) Type() ValueType {
+	if C._go_mrb_nil_p(v.value) == 1 {
+		return TypeNil
+	}
+
 	return ValueType(C._go_mrb_type(v.value))
 }
 


### PR DESCRIPTION
```go
mrb := NewMrb()
defer mrb.Close()

result, _ := mrb.LoadString(`[false]`)
resultArray := result.Array()
val, _ := resultArray.Get(0)
fmt.Printf("%s", val.String())
```
__Expected:__ Print string "false"
__Actual:__ panic: runtime error: invalid memory address or nil pointer dereference

[This check](https://github.com/mitchellh/go-mruby/blob/5776f3208a7e00f8351abdb7470933e06dbd6105/array.go#L28-L31) (which I presume is intended to catch `nil`) is converting boolean false to nil. Mruby nil type isn't really a type and needs special care with the `mrb_nil_p` macro to handle it. IMO this is not a detail that go-mruby users should have to know.

[Hash is similarly affected](https://github.com/mitchellh/go-mruby/blob/5776f3208a7e00f8351abdb7470933e06dbd6105/hash.go#L22-L25)

Sadly there isn't a particularly tidy way to handle this. An MrbValue may contain nil but `ValueType` has no way of expressing this. It will always look like `TypeFalse`.

This patch introduces TypeNil as a go-mruby specific detail. In order to avoid collision with future types the max for uint32 is used (of which ValueType is an alias).

Tests for MrbValue.Type have also been added where possible. Some types don't appear to exposed to userland so these have been left commented.

During testing I also noticed that `Decode` handling is likely to trip up on nil types with `unknown type` errors thrown. It's highly likely that at some point Decode will need to handle this and the most sensible option (IMO) would be to use golang zero types where necessary but that is beyond the scope of this PR.

I stumbled on this while implementing the return helper referenced in #20.