### PR TITLE
Implements checkException helper to internally clear exception state

### DIFF
--- a/array.go
+++ b/array.go
@@ -21,9 +21,6 @@ func (v *Array) Len() int {
 // to the element in the array.
 func (v *Array) Get(idx int) (*MrbValue, error) {
 	result := C.mrb_ary_entry(v.value, C.mrb_int(idx))
-	if v.state.exc != nil {
-		return nil, newExceptionValue(v.state)
-	}
 
 	val := newValue(v.state, result)
 	if val.Type() == TypeNil {

--- a/class.go
+++ b/class.go
@@ -73,8 +73,8 @@ func (c *Class) New(args ...Value) (*MrbValue, error) {
 	}
 
 	result := C.mrb_obj_new(c.mrb.state, c.class, C.mrb_int(len(argv)), argvPtr)
-	if c.mrb.state.exc != nil {
-		return nil, newExceptionValue(c.mrb.state)
+	if exc := checkException(c.mrb.state); exc != nil {
+		return nil, exc
 	}
 
 	return newValue(c.mrb.state, result), nil

--- a/class_test.go
+++ b/class_test.go
@@ -67,6 +67,29 @@ func TestClassNew(t *testing.T) {
 	testCallbackResult(t, value)
 }
 
+func TestClassNewException(t *testing.T) {
+	mrb := NewMrb()
+	defer mrb.Close()
+
+	class := mrb.DefineClass("Hello", mrb.ObjectClass())
+	class.DefineMethod("initialize", testCallbackException, ArgsNone())
+
+	_, err := class.New()
+	if err == nil {
+		t.Fatalf("expected exception")
+	}
+
+	// Verify exception is cleared
+	val, err := mrb.LoadString(`"test"`)
+	if err != nil {
+		t.Fatalf("unexpected exception: %#v", err)
+	}
+
+	if val.String() != "test" {
+		t.Fatalf("expected val 'test', got %#v", val)
+	}
+}
+
 func TestClassValue(t *testing.T) {
 	mrb := NewMrb()
 	defer mrb.Close()

--- a/func_test.go
+++ b/func_test.go
@@ -1,8 +1,6 @@
 package mruby
 
-import (
-	"testing"
-)
+import "testing"
 
 func testCallback(m *Mrb, self *MrbValue) (Value, Value) {
 	return Int(42), nil
@@ -16,4 +14,10 @@ func testCallbackResult(t *testing.T, v *MrbValue) {
 	if v.Fixnum() != 42 {
 		t.Fatalf("bad: %d", v.Fixnum())
 	}
+}
+
+func testCallbackException(m *Mrb, self *MrbValue) (Value, Value) {
+	_, e := m.LoadString(`raise 'Exception'`)
+	v := e.(*Exception)
+	return nil, v.MrbValue
 }

--- a/hash.go
+++ b/hash.go
@@ -15,9 +15,6 @@ type Hash struct {
 func (h *Hash) Delete(key Value) (*MrbValue, error) {
 	keyVal := key.MrbValue(&Mrb{h.state}).value
 	result := C.mrb_hash_delete_key(h.state, h.value, keyVal)
-	if h.state.exc != nil {
-		return nil, newExceptionValue(h.state)
-	}
 
 	val := newValue(h.state, result)
 	if val.Type() == TypeNil {
@@ -31,10 +28,6 @@ func (h *Hash) Delete(key Value) (*MrbValue, error) {
 func (h *Hash) Get(key Value) (*MrbValue, error) {
 	keyVal := key.MrbValue(&Mrb{h.state}).value
 	result := C.mrb_hash_get(h.state, h.value, keyVal)
-	if h.state.exc != nil {
-		return nil, newExceptionValue(h.state)
-	}
-
 	return newValue(h.state, result), nil
 }
 
@@ -42,12 +35,7 @@ func (h *Hash) Get(key Value) (*MrbValue, error) {
 func (h *Hash) Set(key, val Value) error {
 	keyVal := key.MrbValue(&Mrb{h.state}).value
 	valVal := val.MrbValue(&Mrb{h.state}).value
-
 	C.mrb_hash_set(h.state, h.value, keyVal, valVal)
-	if h.state.exc != nil {
-		return newExceptionValue(h.state)
-	}
-
 	return nil
 }
 
@@ -56,9 +44,5 @@ func (h *Hash) Set(key, val Value) error {
 // you see fit.
 func (h *Hash) Keys() (*MrbValue, error) {
 	result := C.mrb_hash_keys(h.state, h.value)
-	if h.state.exc != nil {
-		return nil, newExceptionValue(h.state)
-	}
-
 	return newValue(h.state, result), nil
 }

--- a/hash_test.go
+++ b/hash_test.go
@@ -83,7 +83,7 @@ func TestHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if value != nil {
+	if value.Type() != TypeNil {
 		t.Fatalf("bad: %s", value)
 	}
 }

--- a/value.go
+++ b/value.go
@@ -126,8 +126,9 @@ func (v *MrbValue) call(method string, args []Value, block Value) (*MrbValue, er
 			argvPtr,
 			*blockV)
 	}
-	if v.state.exc != nil {
-		return nil, newExceptionValue(v.state)
+
+	if exc := checkException(v.state); exc != nil {
+		return nil, exc
 	}
 
 	return newValue(v.state, result), nil

--- a/value_test.go
+++ b/value_test.go
@@ -22,6 +22,11 @@ func TestMrbValueCall(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	_, err = value.Call("some_function_that_doesnt_exist")
+	if err == nil {
+		t.Fatalf("expected exception")
+	}
+
 	result, err := value.Call("==", String("foo"))
 	if err != nil {
 		t.Fatalf("err: %s", err)


### PR DESCRIPTION
As discussed on #20, an internal helper to check exception + clear where necessary.

While implementing the tests for this it became apparent that none of the `mrb_ary_*` or `mrb_hash_*` functions actually raise exceptions and they do not appear to look in to the symbol table of the classes to say access `[]` or `[]=`. As such, those exception checks were removed.

One consequence of this is that these functions will never return an error but still have the `error` retval. I'm not sure if we care about breaking the API at this point since very few seem to be using it.

My inclination would be to remove them. Alternatively we could reintroduce the exception checks "just in case" but there is no way that they can actually be tested.