### PR TITLE
Exception backtrace implementation

### DIFF
--- a/gomruby.h
+++ b/gomruby.h
@@ -11,6 +11,7 @@
 #include <mruby/array.h>
 #include <mruby/class.h>
 #include <mruby/compile.h>
+#include <mruby/error.h>
 #include <mruby/irep.h>
 #include <mruby/hash.h>
 #include <mruby/proc.h>

--- a/hash_test.go
+++ b/hash_test.go
@@ -83,7 +83,7 @@ func TestHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if value.Type() != TypeNil {
+	if value != nil {
 		t.Fatalf("bad: %s", value)
 	}
 }


### PR DESCRIPTION
As per discussions on #20, here is the addition of backtrace / error capture for exceptions returned from mruby.

Initially you mentioned you'd like this in a lazy function but I'm not sure there is value in this for reasons similar to the reasons behind `cachedString` (which this PR obsoletes).

Basically we need mrb state to extract the backtrace and we can't guarantee we'll have it so we need to extract the data upfront. Converting backtrace from an mrb array to `[]string` and splitting backtrace[0] doesn't seem like it should be much overhead, especially when considering that this will only get invoked when an exception makes it to a VM exit point.

This implementation is hopefully more palatable than the totally hacked up previous version was, which made several transitions in to the mruby VM via `Call`. I think this was the key concern for your suggestion but this implementation makes no such transitions.

This PR also sneaks in a fix (in a separate commit) for a broken test for `Hash.Delete` that I did not notice due to a dirty working directory. I can pull that out if needs be but it seemed pointless to raise two PRs.