### PR TITLE
Look for libmruby.a in the go-mruby directory

### DIFF
--- a/mruby.go
+++ b/mruby.go
@@ -3,7 +3,7 @@ package mruby
 import "unsafe"
 
 // #cgo CFLAGS: -Ivendor/mruby/include
-// #cgo LDFLAGS: libmruby.a -lm
+// #cgo LDFLAGS: ${SRCDIR}/libmruby.a -lm
 // #include <stdlib.h>
 // #include "gomruby.h"
 import "C"


### PR DESCRIPTION
[Makefile#L12](https://github.com/mitchellh/go-mruby/blob/master/Makefile#L12) copies `libmruby.a` into the go-mruby directory. `mruby.go` should be looking there for it. This fixes the example and works when go-mruby is vendored.

This is a "breaking change" if people are already moving `libmruby.a` into their own project directory, but it fixes #17 and removes need for #6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mitchellh/go-mruby/28)
<!-- Reviewable:end -->
