### PR TITLE
Patches to mruby.go to implement module lookup

### DIFF
--- a/mruby.go
+++ b/mruby.go
@@ -80,6 +80,18 @@ func (m *Mrb) Class(name string, super *Class) *Class {
 	return newClass(m, class)
 }
 
+// Module returns the named module as a *Class. If the module is invalid,
+// NameError is triggered within your program and SIGABRT is sent to the
+// application.
+func (m *Mrb) Module(name string) *Class {
+	cs := C.CString(name)
+	defer C.free(unsafe.Pointer(cs))
+
+	class := C.mrb_module_get(m.state, cs)
+
+	return newClass(m, class)
+}
+
 // Close a Mrb, this must be called to properly free resources, and
 // should only be called once.
 func (m *Mrb) Close() {

--- a/mruby_test.go
+++ b/mruby_test.go
@@ -19,6 +19,16 @@ func TestMrbArena(t *testing.T) {
 	mrb.ArenaRestore(idx)
 }
 
+func TestMrbModule(t *testing.T) {
+	mrb := NewMrb()
+	defer mrb.Close()
+
+	module := mrb.Module("Kernel")
+	if module == nil {
+		t.Fatal("module was nil and should not be")
+	}
+}
+
 func TestMrbClass(t *testing.T) {
 	mrb := NewMrb()
 	defer mrb.Close()


### PR DESCRIPTION
Hi folks, I hope this helps. Here's a more complete example than the tests needed based on the initial example in the README:

```go
package main

import (
  "fmt"

  mruby "github.com/mitchellh/go-mruby"
)

func main() {
  mrb := mruby.NewMrb()
  defer mrb.Close()

  // Our custom function we'll expose to Ruby. The first return
  // value is what to return from the func and the second is an
  // exception to raise (if any).
  addFunc := func(m *mruby.Mrb, self *mruby.MrbValue) (mruby.Value, mruby.Value) {
    args := m.GetArgs()
    return mruby.Int(args[0].Fixnum() + args[1].Fixnum()), nil
  }

  // Lets add a method to Kernel
  class := mrb.Module("Kernel")
  class.DefineClassMethod("add", addFunc, mruby.ArgsReq(2))

  // Let's call it and inspect the result
  result, err := mrb.LoadString(`Kernel.add(10, 15)`)
  if err != nil {
    panic(err.Error())
  }

  // This will output "Result: 42"
  fmt.Printf("Result: %s\n", result.String())
}
```