### PR TITLE
Several fixes to get code `golint` and `go vet` clean

### DIFF
--- a/class.go
+++ b/class.go
@@ -52,16 +52,16 @@ func (c *Class) DefineMethod(name string, cb Func, as ArgSpec) {
 		C.mrb_aspec(as))
 }
 
-// Value returns a *Value for this Class. *Values are sometimes required
+// MrbValue returns a *Value for this Class. *Values are sometimes required
 // as arguments where classes should be valid.
 func (c *Class) MrbValue(m *Mrb) *MrbValue {
 	return newValue(c.mrb.state, C.mrb_obj_value(unsafe.Pointer(c.class)))
 }
 
-// Instantiate the class with the given args.
+// New instantiates the class with the given args.
 func (c *Class) New(args ...Value) (*MrbValue, error) {
-	var argv []C.mrb_value = nil
-	var argvPtr *C.mrb_value = nil
+	var argv []C.mrb_value
+	var argvPtr *C.mrb_value
 	if len(args) > 0 {
 		// Make the raw byte slice to hold our arguments we'll pass to C
 		argv = make([]C.mrb_value, len(args))

--- a/context.go
+++ b/context.go
@@ -13,6 +13,7 @@ type CompileContext struct {
 	mrb      *Mrb
 }
 
+// NewCompileContext constructs a *CompileContext from a *Mrb.
 func NewCompileContext(m *Mrb) *CompileContext {
 	return &CompileContext{
 		ctx: C.mrbc_context_new(m.state),
@@ -20,7 +21,7 @@ func NewCompileContext(m *Mrb) *CompileContext {
 	}
 }
 
-// Closes the context, freeing any resources associated with it.
+// Close the context, freeing any resources associated with it.
 //
 // This is safe to call once the context has been used for parsing/loading
 // any Ruby code.

--- a/decode.go
+++ b/decode.go
@@ -104,11 +104,10 @@ func (d *decoder) decode(name string, v *MrbValue, result reflect.Value) error {
 	case reflect.Struct:
 		return d.decodeStruct(name, v, result)
 	default:
-		return fmt.Errorf(
-			"%s: unknown kind to decode into: %s", name, k.Kind())
 	}
 
-	return nil
+	return fmt.Errorf(
+		"%s: unknown kind to decode into: %s", name, k.Kind())
 }
 
 func (d *decoder) decodeBool(name string, v *MrbValue, result reflect.Value) error {
@@ -188,7 +187,7 @@ func (d *decoder) decodeInterface(name string, v *MrbValue, result reflect.Value
 		set = reflect.Indirect(reflect.New(reflect.TypeOf("")))
 	default:
 		return fmt.Errorf(
-			"%s: cannot decode into interface: %s",
+			"%s: cannot decode into interface: %v",
 			name, t)
 	}
 
@@ -422,9 +421,12 @@ func (d *decoder) decodeStruct(name string, v *MrbValue, result reflect.Value) e
 		}
 	}
 
-	usedKeys := make(map[string]struct{})
-	decodedFields := make([]string, 0, len(fields))
-	decodedFieldsVal := make([]reflect.Value, 0)
+	var (
+		decodedFields    = make([]string, 0, len(fields))
+		decodedFieldsVal = []reflect.Value{}
+		usedKeys         = make(map[string]struct{})
+	)
+
 	for fieldType, field := range fields {
 		if !field.IsValid() {
 			// This should never happen

--- a/mruby.go
+++ b/mruby.go
@@ -31,7 +31,7 @@ func NewMrb() *Mrb {
 	}
 }
 
-// Restores the arena index so the objects between the save and this point
+// ArenaRestore restores the arena index so the objects between the save and this point
 // can be garbage collected in the future.
 //
 // See ArenaSave for more documentation.
@@ -39,7 +39,7 @@ func (m *Mrb) ArenaRestore(idx ArenaIndex) {
 	C.mrb_gc_arena_restore(m.state, C.int(idx))
 }
 
-// This saves the index into the arena.
+// ArenaSave saves the index into the arena.
 //
 // Restore the arena index later by calling ArenaRestore.
 //
@@ -205,8 +205,9 @@ func (m *Mrb) Run(v Value, self Value) (*MrbValue, error) {
 func (m *Mrb) Yield(block Value, args ...Value) (*MrbValue, error) {
 	mrbBlock := block.MrbValue(m)
 
-	var argv []C.mrb_value = nil
-	var argvPtr *C.mrb_value = nil
+	var argv []C.mrb_value
+	var argvPtr *C.mrb_value
+
 	if len(args) > 0 {
 		// Make the raw byte slice to hold our arguments we'll pass to C
 		argv = make([]C.mrb_value, len(args))
@@ -234,7 +235,7 @@ func (m *Mrb) Yield(block Value, args ...Value) (*MrbValue, error) {
 // Functions handling defining new classes/modules in the VM
 //-------------------------------------------------------------------
 
-// Define a new top-level class.
+// DefineClass defines a new top-level class.
 //
 // If super is nil, the class will be defined under Object.
 func (m *Mrb) DefineClass(name string, super *Class) *Class {
@@ -292,22 +293,22 @@ func (m *Mrb) DefineModuleUnder(name string, outer *Class) *Class {
 // Functions below return Values or constant Classes
 //-------------------------------------------------------------------
 
-// Returns the Object top-level class.
+// ObjectClass returns the Object top-level class.
 func (m *Mrb) ObjectClass() *Class {
 	return newClass(m, m.state.object_class)
 }
 
-// Returns the Object top-level class.
+// KernelModule returns the Kernel top-level module.
 func (m *Mrb) KernelModule() *Class {
 	return newClass(m, m.state.kernel_module)
 }
 
-// Returns the top-level `self` value.
+// TopSelf returns the top-level `self` value.
 func (m *Mrb) TopSelf() *MrbValue {
 	return newValue(m.state, C.mrb_obj_value(unsafe.Pointer(m.state.top_self)))
 }
 
-// Returns a Value for "false"
+// FalseValue returns a Value for "false"
 func (m *Mrb) FalseValue() *MrbValue {
 	return newValue(m.state, C.mrb_false_value())
 }
@@ -317,17 +318,17 @@ func (m *Mrb) NilValue() *MrbValue {
 	return newValue(m.state, C.mrb_nil_value())
 }
 
-// Returns a Value for "true"
+// TrueValue returns a Value for "true"
 func (m *Mrb) TrueValue() *MrbValue {
 	return newValue(m.state, C.mrb_true_value())
 }
 
-// Returns a Value for a fixed number.
+// FixnumValue returns a Value for a fixed number.
 func (m *Mrb) FixnumValue(v int) *MrbValue {
 	return newValue(m.state, C.mrb_fixnum_value(C.mrb_int(v)))
 }
 
-// Returns a Value for a string.
+// StringValue returns a Value for a string.
 func (m *Mrb) StringValue(s string) *MrbValue {
 	cs := C.CString(s)
 	defer C.free(unsafe.Pointer(cs))

--- a/value.go
+++ b/value.go
@@ -17,8 +17,13 @@ type Value interface {
 	MrbValue(*Mrb) *MrbValue
 }
 
+// Int is the basic ruby Integer type.
 type Int int
+
+// NilType is the object representation of NilClass
 type NilType [0]byte
+
+// String is objects of the type String.
 type String string
 
 // Nil is a constant that can be used as a Nil Value
@@ -31,38 +36,6 @@ type MrbValue struct {
 	value C.mrb_value
 	state *C.mrb_state
 }
-
-// ValueType is an enum of types that a Value can be and is returned by
-// Value.Type().
-type ValueType uint32
-
-const (
-	TypeFalse     ValueType = iota // 0
-	TypeFree                       // 1
-	TypeTrue                       // 2
-	TypeFixnum                     // 3
-	TypeSymbol                     // 4
-	TypeUndef                      // 5
-	TypeFloat                      // 6
-	TypeCptr                       // 7
-	TypeObject                     // 8
-	TypeClass                      // 9
-	TypeModule                     // 10
-	TypeIClass                     // 11
-	TypeSClass                     // 12
-	TypeProc                       // 13
-	TypeArray                      // 14
-	TypeHash                       // 15
-	TypeString                     // 16
-	TypeRange                      // 17
-	TypeException                  // 18
-	TypeFile                       // 19
-	TypeEnv                        // 20
-	TypeData                       // 21
-	TypeFiber                      // 22
-	TypeMaxDefine                  // 23
-	TypeNil       ValueType = 0xffffffff
-)
 
 func init() {
 	Nil = [0]byte{}
@@ -87,8 +60,8 @@ func (v *MrbValue) CallBlock(method string, args ...Value) (*MrbValue, error) {
 }
 
 func (v *MrbValue) call(method string, args []Value, block Value) (*MrbValue, error) {
-	var argv []C.mrb_value = nil
-	var argvPtr *C.mrb_value = nil
+	var argv []C.mrb_value
+	var argvPtr *C.mrb_value
 
 	if len(args) > 0 {
 		// Make the raw byte slice to hold our arguments we'll pass to C
@@ -158,6 +131,7 @@ func (v *MrbValue) SetProcTargetClass(c *Class) {
 	proc.target_class = c.class
 }
 
+// Type returns the ValueType of the MrbValue. See the constants table.
 func (v *MrbValue) Type() ValueType {
 	if C._go_mrb_nil_p(v.value) == 1 {
 		return TypeNil
@@ -229,14 +203,17 @@ func (v *MrbValue) String() string {
 // Native Go types implementing the Value interface
 //-------------------------------------------------------------------
 
+// MrbValue returns the native MRB value
 func (i Int) MrbValue(m *Mrb) *MrbValue {
 	return m.FixnumValue(int(i))
 }
 
+// MrbValue returns the native MRB value
 func (NilType) MrbValue(m *Mrb) *MrbValue {
 	return m.NilValue()
 }
 
+// MrbValue returns the native MRB value
 func (s String) MrbValue(m *Mrb) *MrbValue {
 	return m.StringValue(string(s))
 }

--- a/value_type.go
+++ b/value_type.go
@@ -1,0 +1,33 @@
+package mruby
+
+// ValueType is an enum of types that a Value can be and is returned by
+// Value.Type().
+type ValueType uint32
+
+const (
+	TypeFalse     ValueType = iota // 0
+	TypeFree                       // 1
+	TypeTrue                       // 2
+	TypeFixnum                     // 3
+	TypeSymbol                     // 4
+	TypeUndef                      // 5
+	TypeFloat                      // 6
+	TypeCptr                       // 7
+	TypeObject                     // 8
+	TypeClass                      // 9
+	TypeModule                     // 10
+	TypeIClass                     // 11
+	TypeSClass                     // 12
+	TypeProc                       // 13
+	TypeArray                      // 14
+	TypeHash                       // 15
+	TypeString                     // 16
+	TypeRange                      // 17
+	TypeException                  // 18
+	TypeFile                       // 19
+	TypeEnv                        // 20
+	TypeData                       // 21
+	TypeFiber                      // 22
+	TypeMaxDefine                  // 23
+	TypeNil       ValueType = 0xffffffff
+)


### PR DESCRIPTION
This change is a little bigger but incorporates only one logic change, an unreachable code section found by go vet.

This gets closer to golint happiness too; it only complains about snake case names now. If desirable, I can rewrite the C as well to get golint 100% happy.