### PR TITLE
Move to mruby 1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MRUBY_COMMIT ?= 57e30b3be3146bae437cfd0ffdfd630dde956ef9
+MRUBY_COMMIT ?= 1.2.0
 
 all: libmruby.a
 	go test


### PR DESCRIPTION
I've found this to be a little more reliable when it comes to GC and handling of method args, I'm not actually sure if it's related though. There is a patch in here that seems to suggest there is, and this is the latest point release. It's about a week later than the patch you're currently using in here.

Here's the changelog if it helps you make an informed decision: https://gist.github.com/anonymous/3381d47d9339fa51cc899c0d7fe14c28