### PR TITLE
Golint patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 MRUBY_COMMIT ?= 1.2.0
 
-all: libmruby.a
-	go test
+all: libmruby.a test
 
 clean:
 	rm -rf vendor
 	rm -f libmruby.a
+
+lint:
+	sh golint.sh
 
 libmruby.a: vendor/mruby
 	cd vendor/mruby && ${MAKE}
@@ -17,4 +19,7 @@ vendor/mruby:
 	cd vendor/mruby && git reset --hard && git clean -fdx
 	cd vendor/mruby && git checkout ${MRUBY_COMMIT}
 
-.PHONY: all clean libmruby.a test
+test: lint
+	go test -v
+
+.PHONY: all clean libmruby.a test lint

--- a/args.go
+++ b/args.go
@@ -48,7 +48,7 @@ func ArgsOpt(n int) ArgSpec {
 var getArgAccumulator []*C.mrb_value
 var getArgLock sync.Mutex
 
-//export go_get_arg_append
-func go_get_arg_append(v *C.mrb_value) {
+//export goGetArgAppend
+func goGetArgAppend(v *C.mrb_value) {
 	getArgAccumulator = append(getArgAccumulator, v)
 }

--- a/func.go
+++ b/func.go
@@ -29,8 +29,8 @@ func init() {
 	stateMethodTable = make(stateMethodMap)
 }
 
-//export go_mrb_func_call
-func go_mrb_func_call(s *C.mrb_state, v *C.mrb_value, c_exc *C.mrb_value) C.mrb_value {
+//export goMRBFuncCall
+func goMRBFuncCall(s *C.mrb_state, v *C.mrb_value, callExc *C.mrb_value) C.mrb_value {
 	// Lookup the classes that we've registered methods for in this state
 	classTable := stateMethodTable[s]
 	if classTable == nil {
@@ -58,7 +58,7 @@ func go_mrb_func_call(s *C.mrb_state, v *C.mrb_value, c_exc *C.mrb_value) C.mrb_
 	result, exc := f(mrb, newValue(s, *v))
 
 	if exc != nil {
-		*c_exc = exc.MrbValue(mrb).value
+		*callExc = exc.MrbValue(mrb).value
 		return mrb.NilValue().value
 	}
 

--- a/golint.sh
+++ b/golint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+version=$(go version | awk '{ print $3 }' | awk -F. '{ print $2 }')
+
+if [ "$version" != "5" ]
+then
+  echo "Installing golint into your GOPATH..."
+  go get github.com/golang/lint/...
+  echo "Checking with golint..."
+  golint ./...
+fi

--- a/gomruby.h
+++ b/gomruby.h
@@ -25,15 +25,15 @@
 //-------------------------------------------------------------------
 // This is declard in func.go and is a way for us to call back into
 // Go to execute a method.
-extern mrb_value go_mrb_func_call(mrb_state*, mrb_value*, mrb_value*);
+extern mrb_value goMRBFuncCall(mrb_state*, mrb_value*, mrb_value*);
 
 // This calls into Go with a similar signature to mrb_func_t. We have to
 // change it slightly because cgo can't handle the union type of mrb_value,
 // so we pass in a pointer instead. Additionally, the result is also a
 // pointer to work around Go's confusion with unions.
-static inline mrb_value _go_mrb_func_call(mrb_state *s, mrb_value self) {
+static inline mrb_value _goMRBFuncCall(mrb_state *s, mrb_value self) {
     mrb_value exc = mrb_nil_value();
-    mrb_value result = go_mrb_func_call(s, &self, &exc);
+    mrb_value result = goMRBFuncCall(s, &self, &exc);
     // We raise if we got an exception. We have to raise from here and
     // not from within Go because it messes with Go's calling conventions,
     // resulting in a broken stack.
@@ -47,7 +47,7 @@ static inline mrb_value _go_mrb_func_call(mrb_state *s, mrb_value self) {
 // This method is used as a way to get a valid mrb_func_t that actually
 // just calls back into Go.
 static inline mrb_func_t _go_mrb_func_t() {
-    return &_go_mrb_func_call;
+    return &_goMRBFuncCall;
 }
 
 //-------------------------------------------------------------------
@@ -89,7 +89,7 @@ static mrb_value _go_mrb_yield_argv(mrb_state *mrb, mrb_value b, mrb_int argc, c
 // Helpers to deal with getting arguments
 //-------------------------------------------------------------------
 // This is declard in args.go
-extern void go_get_arg_append(mrb_value*);
+extern void goGetArgAppend(mrb_value*);
 
 // This gets all arguments given to a function call and adds them to
 // the accumulator in Go.
@@ -100,11 +100,11 @@ static inline int _go_mrb_get_args_all(mrb_state *s) {
 
     count = mrb_get_args(s, "*&", &argv, &argc, &block);
     for (i = 0; i < argc; i++) {
-        go_get_arg_append(&argv[i]);
+        goGetArgAppend(&argv[i]);
     }
 
     if (!mrb_nil_p(block)) {
-        go_get_arg_append(&block);
+        goGetArgAppend(&block);
     }
 
     return count;

--- a/parser.go
+++ b/parser.go
@@ -12,7 +12,7 @@ import "C"
 
 // Parser is a parser for Ruby code.
 type Parser struct {
-	code string
+	code   string
 	mrb    *Mrb
 	parser *C.struct_mrb_parser_state
 }
@@ -59,7 +59,7 @@ func (p *Parser) Parse(code string, c *CompileContext) ([]*ParserMessage, error)
 	p.parser.s = s
 	p.parser.send = C._go_mrb_calc_send(s)
 
-	var ctx *C.mrbc_context = nil
+	var ctx *C.mrbc_context
 	if c != nil {
 		ctx = c.ctx
 	}

--- a/value_type.go
+++ b/value_type.go
@@ -5,29 +5,54 @@ package mruby
 type ValueType uint32
 
 const (
-	TypeFalse     ValueType = iota // 0
-	TypeFree                       // 1
-	TypeTrue                       // 2
-	TypeFixnum                     // 3
-	TypeSymbol                     // 4
-	TypeUndef                      // 5
-	TypeFloat                      // 6
-	TypeCptr                       // 7
-	TypeObject                     // 8
-	TypeClass                      // 9
-	TypeModule                     // 10
-	TypeIClass                     // 11
-	TypeSClass                     // 12
-	TypeProc                       // 13
-	TypeArray                      // 14
-	TypeHash                       // 15
-	TypeString                     // 16
-	TypeRange                      // 17
-	TypeException                  // 18
-	TypeFile                       // 19
-	TypeEnv                        // 20
-	TypeData                       // 21
-	TypeFiber                      // 22
-	TypeMaxDefine                  // 23
-	TypeNil       ValueType = 0xffffffff
+	// TypeFalse is `false`
+	TypeFalse ValueType = iota
+	// TypeFree is ?
+	TypeFree
+	// TypeTrue is `true`
+	TypeTrue
+	// TypeFixnum is fixnums, or integers for this case.
+	TypeFixnum
+	// TypeSymbol is for entities in ruby that look like `:this`
+	TypeSymbol
+	// TypeUndef is a value internal to ruby for uninstantiated vars.
+	TypeUndef
+	// TypeFloat is any floating point number such as 1.2, etc.
+	TypeFloat
+	// TypeCptr is a void*
+	TypeCptr
+	// TypeObject is a standard ruby object, base class of most instantiated objects.
+	TypeObject
+	// TypeClass is the base class of all classes.
+	TypeClass
+	// TypeModule is the base class of all Modules.
+	TypeModule
+	// TypeIClass is ?
+	TypeIClass
+	// TypeSClass is ?
+	TypeSClass
+	// TypeProc are procs (concrete block definitons)
+	TypeProc
+	// TypeArray is []
+	TypeArray
+	// TypeHash is { }
+	TypeHash
+	// TypeString is ""
+	TypeString
+	// TypeRange is (0..x)
+	TypeRange
+	// TypeException is raised when using the raise keyword
+	TypeException
+	// TypeFile is for objects of the File class
+	TypeFile
+	// TypeEnv is for getenv/setenv etc
+	TypeEnv
+	// TypeData is ?
+	TypeData
+	// TypeFiber is for members of the Fiber class
+	TypeFiber
+	// TypeMaxDefine is ?
+	TypeMaxDefine
+	// TypeNil is nil
+	TypeNil ValueType = 0xffffffff
 )


### PR DESCRIPTION
This integrates golint into the workflow so it can be used to both enforce it at test time, effectively enabling it for CI runs.

It also provides the necessary patches to satisfy the build; it changes a few things regarding the C calling convention to fit the function name requirements.

golint has no way to special-exception code, there was an closed ticket (I can find it if you want) with the developer stating WONTFIX essentially. That means we can do a few things:

* Re-package according to whether we want to golint or not (I don't like this idea)
* Write tooling around special casing files
* Make everything golint happy

I chose the latter as you can see in the patch; I re-did the comments in value_type.go. The values don't show up anymore in the godoc, but I tried to describe what the type is for instead, briefly.