### PR TITLE
Apply a warning message recommending vendoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Compiling/installing the go-mruby library should work on Linux, Mac OS X,
 and Windows. On Windows, msys is the only supported build toolchain (same
 as Go itself).
 
+**Due to this linking, it is strongly recommended that you vendor this
+repository and bake our build system into your process.**
+
 ### Customizing the mruby Compilation
 
 You can customize the mruby compilation by setting a couple environmental


### PR DESCRIPTION
@mikesimons pointed out in #18 that vendoring the repo is really the only safe way to rely on the version of libmruby.a in use. I generally agree that this should be vendored and is what I'm doing myself for my own projects.

I have supplied this documentation change to reflect that opinion as a best practice. Let me know what you think.