### PR TITLE
Implement mrb_context_run.

### DIFF
--- a/gomruby.h
+++ b/gomruby.h
@@ -231,4 +231,10 @@ static inline void _go_mrb_context_set_capture_errors(struct mrbc_context *ctx, 
   }
 }
 
+static inline mrb_value _go_mrb_context_run(mrb_state *m, struct RProc *proc, mrb_value self, int *stack_keep) {
+  mrb_value result = mrb_context_run(m, proc, self, *stack_keep);
+  *stack_keep = proc->body.irep->nlocals;
+  return result;
+}
+
 #endif

--- a/mruby_test.go
+++ b/mruby_test.go
@@ -444,4 +444,28 @@ func TestMrbRun(t *testing.T) {
 	if rval.String() != "rval" {
 		t.Fatalf("expected return value 'rval', got %#v", rval)
 	}
+
+	parser.Parse(`a = 10`, context)
+	proc = parser.GenerateCode()
+
+	stackKeep, ret, err := mrb.RunWithContext(proc, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stackKeep != 2 {
+		t.Fatalf("stack value was %d not 2; some variables may not have been captured", stackKeep)
+	}
+
+	parser.Parse(`a`, context)
+	proc = parser.GenerateCode()
+
+	stackKeep, ret, err = mrb.RunWithContext(proc, nil, stackKeep)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret.String() != "10" {
+		t.Fatalf("Captured variable was not expected value: was %q", ret.String())
+	}
 }


### PR DESCRIPTION
mrb_context_run is capable of trapping the stack, making it useful in f.e. mirb
and box's repl. A basic implementation and tests are provided.

RunWithContext returns a magic integer that describes the stack in place, so
that it can be re-used on the next call. This is how local variables traverse
ruby parse invocations.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>