### PR TITLE
Introduce CompileContext.CaptureErrors to enable error swallowing in the parser

### DIFF
--- a/context.go
+++ b/context.go
@@ -8,9 +8,10 @@ import "C"
 // CompileContexts keep track of things such as filenames, line numbers,
 // as well as some settings for how to parse and execute code.
 type CompileContext struct {
-	ctx      *C.mrbc_context
-	filename string
-	mrb      *Mrb
+	ctx           *C.mrbc_context
+	filename      string
+	mrb           *Mrb
+	captureErrors bool
 }
 
 // NewCompileContext constructs a *CompileContext from a *Mrb.
@@ -40,4 +41,16 @@ func (c *CompileContext) Filename() string {
 func (c *CompileContext) SetFilename(f string) {
 	c.filename = f
 	c.ctx.filename = C.CString(c.filename)
+}
+
+// CaptureErrors toggles the capture errors feature of the parser, which
+// swallows errors. This allows repls and other partial parsing tools
+// (formatters, f.e.) to function.
+func (c *CompileContext) CaptureErrors(yes bool) {
+	state := 0
+	if yes {
+		state = 1
+	}
+
+	C._go_mrb_context_set_capture_errors(c.ctx, C.int(state))
 }

--- a/gomruby.h
+++ b/gomruby.h
@@ -223,4 +223,12 @@ static inline int _go_gc_live(mrb_state *m) {
   return gc->live;
 }
 
+static inline void _go_mrb_context_set_capture_errors(struct mrbc_context *ctx, int state) {
+  ctx->capture_errors = FALSE;
+
+  if (state != 0) {
+    ctx->capture_errors = TRUE;
+  }
+}
+
 #endif


### PR DESCRIPTION
since it prints these to stderr without any seeming way to change that, I'm not sure if this is easy to test. I have tested it in a project that uses this.

With this feature, you can turn off automatic error reporting to stderr from the mruby engine. This is particularly annoying when trying to implement a REPL as you will get a warning on any multiline input.