### PR TITLE
Stability & Concurrency Fixes

### DIFF
--- a/args.go
+++ b/args.go
@@ -1,8 +1,6 @@
 package mruby
 
-import (
-	"sync"
-)
+import "sync"
 
 // #include "gomruby.h"
 import "C"
@@ -45,10 +43,10 @@ func ArgsOpt(n int) ArgSpec {
 
 // The global accumulator when Mrb.GetArgs is called. There is a
 // global lock around this so that the access to it is safe.
-var getArgAccumulator []*C.mrb_value
-var getArgLock sync.Mutex
+var getArgAccumulator []C.mrb_value
+var getArgLock = new(sync.Mutex)
 
 //export goGetArgAppend
-func goGetArgAppend(v *C.mrb_value) {
+func goGetArgAppend(v C.mrb_value) {
 	getArgAccumulator = append(getArgAccumulator, v)
 }

--- a/func.go
+++ b/func.go
@@ -39,11 +39,13 @@ type stateMethods struct {
 
 // stateMethodTable is the lookup table for methods that we define in Go and
 // expose in Ruby. This is cleaned up by Mrb.Close.
-var stateMethodTable = &stateMethods{}
+var stateMethodTable *stateMethods
 
 func init() {
-	stateMethodTable.Mutex = new(sync.Mutex)
-	stateMethodTable.Map = make(stateMethodMap)
+	stateMethodTable = &stateMethods{
+		Mutex: new(sync.Mutex),
+		Map:   make(stateMethodMap),
+	}
 }
 
 //export goMRBFuncCall

--- a/func.go
+++ b/func.go
@@ -2,6 +2,7 @@ package mruby
 
 import (
 	"fmt"
+	"sync"
 	"unsafe"
 )
 
@@ -17,22 +18,40 @@ import "C"
 // The second return value is an exception, if any. This will be raised.
 type Func func(m *Mrb, self *MrbValue) (Value, Value)
 
-type classMethodMap map[*C.struct_RClass]methodMap
+type classMethodMap map[*C.struct_RClass]*methods
 type methodMap map[C.mrb_sym]Func
-type stateMethodMap map[*C.mrb_state]classMethodMap
+type stateMethodMap map[*C.mrb_state]*classMethods
+
+type classMethods struct {
+	Map   classMethodMap
+	Mutex *sync.Mutex
+}
+
+type methods struct {
+	Map   methodMap
+	Mutex *sync.Mutex
+}
+
+type stateMethods struct {
+	Map   stateMethodMap
+	Mutex *sync.Mutex
+}
 
 // stateMethodTable is the lookup table for methods that we define in Go and
 // expose in Ruby. This is cleaned up by Mrb.Close.
-var stateMethodTable stateMethodMap
+var stateMethodTable = &stateMethods{}
 
 func init() {
-	stateMethodTable = make(stateMethodMap)
+	stateMethodTable.Mutex = new(sync.Mutex)
+	stateMethodTable.Map = make(stateMethodMap)
 }
 
 //export goMRBFuncCall
 func goMRBFuncCall(s *C.mrb_state, v *C.mrb_value, callExc *C.mrb_value) C.mrb_value {
 	// Lookup the classes that we've registered methods for in this state
-	classTable := stateMethodTable[s]
+	stateMethodTable.Mutex.Lock()
+	classTable := stateMethodTable.Map[s]
+	stateMethodTable.Mutex.Unlock()
 	if classTable == nil {
 		panic(fmt.Sprintf("func call from unknown state: %p", s))
 	}
@@ -41,13 +60,17 @@ func goMRBFuncCall(s *C.mrb_state, v *C.mrb_value, callExc *C.mrb_value) C.mrb_v
 	ci := s.c.ci
 
 	// Lookup the class itself
-	methodTable := classTable[ci.proc.target_class]
+	classTable.Mutex.Lock()
+	methodTable := classTable.Map[ci.proc.target_class]
+	classTable.Mutex.Unlock()
 	if methodTable == nil {
 		panic(fmt.Sprintf("func call on unknown class"))
 	}
 
 	// Lookup the method
-	f := methodTable[ci.mid]
+	methodTable.Mutex.Lock()
+	f := methodTable.Map[ci.mid]
+	methodTable.Mutex.Unlock()
 	if f == nil {
 		panic(fmt.Sprintf("func call on unknown method"))
 	}
@@ -71,21 +94,27 @@ func goMRBFuncCall(s *C.mrb_state, v *C.mrb_value, callExc *C.mrb_value) C.mrb_v
 }
 
 func insertMethod(s *C.mrb_state, c *C.struct_RClass, n string, f Func) {
-	classLookup := stateMethodTable[s]
+	stateMethodTable.Mutex.Lock()
+	classLookup := stateMethodTable.Map[s]
 	if classLookup == nil {
-		classLookup = make(classMethodMap)
-		stateMethodTable[s] = classLookup
+		classLookup = &classMethods{Map: make(classMethodMap), Mutex: new(sync.Mutex)}
+		stateMethodTable.Map[s] = classLookup
 	}
+	stateMethodTable.Mutex.Unlock()
 
-	methodLookup := classLookup[c]
+	classLookup.Mutex.Lock()
+	methodLookup := classLookup.Map[c]
 	if methodLookup == nil {
-		methodLookup = make(methodMap)
-		classLookup[c] = methodLookup
+		methodLookup = &methods{Map: make(methodMap), Mutex: new(sync.Mutex)}
+		classLookup.Map[c] = methodLookup
 	}
+	classLookup.Mutex.Unlock()
 
 	cs := C.CString(n)
 	defer C.free(unsafe.Pointer(cs))
 
 	sym := C.mrb_intern_cstr(s, cs)
-	methodLookup[sym] = f
+	methodLookup.Mutex.Lock()
+	methodLookup.Map[sym] = f
+	methodLookup.Mutex.Unlock()
 }

--- a/func.go
+++ b/func.go
@@ -88,6 +88,7 @@ func goMRBFuncCall(s *C.mrb_state, v C.mrb_value) C.mrb_value {
 
 	if exc != nil {
 		s.exc = C._go_mrb_getobj(exc.MrbValue(mrb).value)
+		return mrb.NilValue().value
 	}
 
 	return result.MrbValue(mrb).value

--- a/gomruby.h
+++ b/gomruby.h
@@ -99,25 +99,22 @@ static inline int _go_mrb_get_args_all(mrb_state *s) {
     mrb_value *argv;
     mrb_value block;
     mrb_bool append;
-    int argc, i, count;
+    int argc, i;
 
-    count = mrb_get_args(s, "*&?", &argv, &argc, &block, &append);
-    if (count < 0 || errno != 0) {
-        return count;
-    }
+    mrb_get_args(s, "*&?", &argv, &argc, &block, &append);
 
     for (i = 0; i < argc; i++) {
         goGetArgAppend(argv[i]);
     }
 
     if (append == FALSE || mrb_type(block) == MRB_TT_FALSE) {
-        return count;
+        return argc;
     }
 
-    count++;
+    argc++;
     goGetArgAppend(block);
 
-    return count;
+    return argc;
 }
 
 //-------------------------------------------------------------------

--- a/gomruby.h
+++ b/gomruby.h
@@ -77,6 +77,16 @@ static mrb_value _go_mrb_yield_argv(mrb_state *mrb, mrb_value b, mrb_int argc, c
     GOMRUBY_EXC_PROTECT_END
 }
 
+static mrb_value _go_mrb_call(mrb_state *mrb, mrb_value b, mrb_sym method, mrb_int argc, const mrb_value *argv, mrb_value *block) {
+  GOMRUBY_EXC_PROTECT_START
+  if (block != NULL) {
+		result = mrb_funcall_with_block(mrb, b, method, argc, argv, *block);
+  } else {
+    result = mrb_funcall_argv(mrb, b, method, argc, argv);
+  }
+  GOMRUBY_EXC_PROTECT_END
+}
+
 //-------------------------------------------------------------------
 // Helpers to deal with getting arguments
 //-------------------------------------------------------------------

--- a/mruby.go
+++ b/mruby.go
@@ -160,13 +160,10 @@ func (m *Mrb) GetArgs() []*MrbValue {
 	values := make([]*MrbValue, len(getArgAccumulator))
 	for i, v := range getArgAccumulator {
 		values[i] = newValue(m.state, *v)
-
-		// Unset the accumulator value for GC
-		getArgAccumulator[i] = nil
 	}
 
 	// Clear reset the accumulator to zero length
-	getArgAccumulator = getArgAccumulator[:0]
+	getArgAccumulator = make([]*C.mrb_value, 0, 5)
 
 	return values
 }

--- a/mruby.go
+++ b/mruby.go
@@ -147,23 +147,18 @@ func (m *Mrb) GetArgs() []*MrbValue {
 	getArgLock.Lock()
 	defer getArgLock.Unlock()
 
-	// If we haven't initialized the accumulator yet, do it. We then
-	// keep this slice cached around forever.
-	if getArgAccumulator == nil {
-		getArgAccumulator = make([]*C.mrb_value, 0, 5)
-	}
+	// Clear reset the accumulator to zero length
+	getArgAccumulator = make([]C.mrb_value, 0, C._go_get_max_funcall_args())
 
 	// Get all the arguments and put it into our accumulator
-	C._go_mrb_get_args_all(m.state)
+	count := C._go_mrb_get_args_all(m.state)
 
 	// Convert those all to values
-	values := make([]*MrbValue, len(getArgAccumulator))
-	for i, v := range getArgAccumulator {
-		values[i] = newValue(m.state, *v)
-	}
+	values := make([]*MrbValue, count)
 
-	// Clear reset the accumulator to zero length
-	getArgAccumulator = make([]*C.mrb_value, 0, 5)
+	for i := 0; i < int(count); i++ {
+		values[i] = newValue(m.state, getArgAccumulator[i])
+	}
 
 	return values
 }

--- a/mruby.go
+++ b/mruby.go
@@ -113,7 +113,9 @@ func (m *Mrb) Module(name string) *Class {
 // should only be called once.
 func (m *Mrb) Close() {
 	// Delete all the methods from the state
-	delete(stateMethodTable, m.state)
+	stateMethodTable.Mutex.Lock()
+	delete(stateMethodTable.Map, m.state)
+	stateMethodTable.Mutex.Unlock()
 
 	// Close the state
 	C.mrb_close(m.state)

--- a/mruby_test.go
+++ b/mruby_test.go
@@ -236,7 +236,7 @@ func TestMrbGetArgs(t *testing.T) {
 
 	// lots of this effort is centered around testing multithreaded behavior.
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1000; i++ {
 
 		errChan := make(chan error, len(cases))
 

--- a/mruby_test.go
+++ b/mruby_test.go
@@ -189,12 +189,14 @@ func TestMrbFullGC(t *testing.T) {
 	}
 }
 
+type testcase struct {
+	args   string
+	types  []ValueType
+	result []string
+}
+
 func TestMrbGetArgs(t *testing.T) {
-	cases := []struct {
-		args   string
-		types  []ValueType
-		result []string
-	}{
+	cases := []testcase{
 		{
 			`("foo")`,
 			[]ValueType{TypeString},
@@ -232,50 +234,71 @@ func TestMrbGetArgs(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		var actual []*MrbValue
-		testFunc := func(m *Mrb, self *MrbValue) (Value, Value) {
-			actual = m.GetArgs()
-			return self, nil
+	// lots of this effort is centered around testing multithreaded behavior.
+
+	for i := 0; i < 10; i++ {
+
+		errChan := make(chan error, len(cases))
+
+		for _, tc := range cases {
+			go func(tc testcase) {
+				var actual []*MrbValue
+				testFunc := func(m *Mrb, self *MrbValue) (Value, Value) {
+					actual = m.GetArgs()
+					return self, nil
+				}
+
+				mrb := NewMrb()
+				defer mrb.Close()
+				class := mrb.DefineClass("Hello", mrb.ObjectClass())
+				class.DefineClassMethod("test", testFunc, ArgsAny())
+				_, err := mrb.LoadString(fmt.Sprintf("Hello.test%s", tc.args))
+				if err != nil {
+					errChan <- fmt.Errorf("err: %s", err)
+					return
+				}
+
+				if tc.result != nil {
+					if len(actual) != len(tc.result) {
+						errChan <- fmt.Errorf("%s: expected %d, got %d",
+							tc.args, len(tc.result), len(actual))
+						return
+					}
+				}
+
+				actualStrings := make([]string, len(actual))
+				actualTypes := make([]ValueType, len(actual))
+				for i, v := range actual {
+					str, err := v.Call("inspect")
+					if err != nil {
+						t.Fatalf("err: %s", err)
+					}
+
+					actualStrings[i] = str.String()
+					actualTypes[i] = v.Type()
+				}
+
+				if !reflect.DeepEqual(actualTypes, tc.types) {
+					errChan <- fmt.Errorf("code: %s\nexpected: %#v\nactual: %#v",
+						tc.args, tc.types, actualTypes)
+					return
+				}
+
+				if tc.result != nil {
+					if !reflect.DeepEqual(actualStrings, tc.result) {
+						errChan <- fmt.Errorf("expected: %#v\nactual: %#v",
+							tc.result, actualStrings)
+						return
+					}
+				}
+
+				errChan <- nil
+			}(tc)
 		}
 
-		mrb := NewMrb()
-		defer mrb.Close()
-		class := mrb.DefineClass("Hello", mrb.ObjectClass())
-		class.DefineClassMethod("test", testFunc, ArgsAny())
-		_, err := mrb.LoadString(fmt.Sprintf("Hello.test%s", tc.args))
-		if err != nil {
-			t.Fatalf("err: %s", err)
-		}
-
-		if tc.result != nil {
-			if len(actual) != len(tc.result) {
-				t.Fatalf("%s: expected %d, got %d",
-					tc.args, len(tc.result), len(actual))
-			}
-		}
-
-		actualStrings := make([]string, len(actual))
-		actualTypes := make([]ValueType, len(actual))
-		for i, v := range actual {
-			str, err := v.Call("inspect")
-			if err != nil {
-				t.Fatalf("err: %s", err)
-			}
-
-			actualStrings[i] = str.String()
-			actualTypes[i] = v.Type()
-		}
-
-		if !reflect.DeepEqual(actualTypes, tc.types) {
-			t.Fatalf("code: %s\nexpected: %#v\nactual: %#v",
-				tc.args, tc.types, actualTypes)
-		}
-
-		if tc.result != nil {
-			if !reflect.DeepEqual(actualStrings, tc.result) {
-				t.Fatalf("expected: %#v\nactual: %#v",
-					tc.result, actualStrings)
+		for range cases {
+			if err := <-errChan; err != nil {
+				t.Fatal(err)
 			}
 		}
 	}
@@ -467,5 +490,32 @@ func TestMrbRun(t *testing.T) {
 
 	if ret.String() != "10" {
 		t.Fatalf("Captured variable was not expected value: was %q", ret.String())
+	}
+}
+
+func TestMrbDefineMethodConcurrent(t *testing.T) {
+	concurrency := 100
+	numFuncs := 100
+
+	cb := func(m *Mrb, self *MrbValue) (Value, Value) {
+		return m.GetArgs()[0], nil
+	}
+
+	syncChan := make(chan struct{}, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			mrb := NewMrb()
+			defer mrb.Close()
+			for i := 0; i < numFuncs; i++ {
+				mrb.TopSelf().SingletonClass().DefineMethod(fmt.Sprintf("test%d", i), cb, ArgsAny())
+			}
+
+			syncChan <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < concurrency; i++ {
+		<-syncChan
 	}
 }

--- a/value.go
+++ b/value.go
@@ -63,11 +63,13 @@ func (v *MrbValue) call(method string, args []Value, block Value) (*MrbValue, er
 	var argv []C.mrb_value
 	var argvPtr *C.mrb_value
 
+	mrb := &Mrb{v.state}
+
 	if len(args) > 0 {
 		// Make the raw byte slice to hold our arguments we'll pass to C
 		argv = make([]C.mrb_value, len(args))
 		for i, arg := range args {
-			argv[i] = arg.MrbValue(&Mrb{v.state}).value
+			argv[i] = arg.MrbValue(mrb).value
 		}
 
 		argvPtr = &argv[0]
@@ -75,7 +77,7 @@ func (v *MrbValue) call(method string, args []Value, block Value) (*MrbValue, er
 
 	var blockV *C.mrb_value
 	if block != nil {
-		val := block.MrbValue(&Mrb{v.state}).value
+		val := block.MrbValue(mrb).value
 		blockV = &val
 	}
 

--- a/value.go
+++ b/value.go
@@ -86,23 +86,13 @@ func (v *MrbValue) call(method string, args []Value, block Value) (*MrbValue, er
 
 	// If we have a block, we have to call a separate function to
 	// pass a block in. Otherwise, we just call it directly.
-	var result C.mrb_value
-	if blockV == nil {
-		result = C.mrb_funcall_argv(
-			v.state,
-			v.value,
-			C.mrb_intern_cstr(v.state, cs),
-			C.mrb_int(len(argv)),
-			argvPtr)
-	} else {
-		result = C.mrb_funcall_with_block(
-			v.state,
-			v.value,
-			C.mrb_intern_cstr(v.state, cs),
-			C.mrb_int(len(argv)),
-			argvPtr,
-			*blockV)
-	}
+	result := C._go_mrb_call(
+		v.state,
+		v.value,
+		C.mrb_intern_cstr(v.state, cs),
+		C.mrb_int(len(argv)),
+		argvPtr,
+		blockV)
 
 	if exc := checkException(v.state); exc != nil {
 		return nil, exc


### PR DESCRIPTION
The commit messages go into detail, but here are the outlying issues it resolves:

* Concurrent access to the mruby library (in and out)
* A potential issue where the stack would get lost when accessed quickly enough between invocations (e.g., in a concurrent scenario)
* An issue where a proc would sometimes be returned as false (due to union length)
* Exception handling when more than 1 go-mruby binding is touched in a single call stack

HTH. Sorry for the noise on the previous tickets.