### PR TITLE
Expose mrb_iv_get/set, mrb_gv_get/set to Go in a consistent fashion.

### DIFF
--- a/gomruby.h
+++ b/gomruby.h
@@ -252,4 +252,20 @@ static inline struct RObject* _go_mrb_getobj(mrb_value v) {
   return mrb_obj_ptr(v);
 }
 
+static inline void _go_mrb_iv_set(mrb_state *m, mrb_value self, mrb_sym sym, mrb_value v) {
+  mrb_iv_set(m, self, sym, v);
+}
+
+static inline mrb_value _go_mrb_iv_get(mrb_state *m, mrb_value self, mrb_sym sym) {
+  return mrb_iv_get(m, self, sym);
+}
+
+static inline void _go_mrb_gv_set(mrb_state *m, mrb_sym sym, mrb_value v) {
+  mrb_gv_set(m, sym, v);
+}
+
+static inline mrb_value _go_mrb_gv_get(mrb_state *m, mrb_sym sym) {
+  return mrb_gv_get(m, sym);
+}
+
 #endif

--- a/mruby.go
+++ b/mruby.go
@@ -13,6 +13,22 @@ type Mrb struct {
 	state *C.mrb_state
 }
 
+// GetGlobalVariable returns the value of the global variable by the given name.
+func (m *Mrb) GetGlobalVariable(name string) *MrbValue {
+	cs := C.CString(name)
+	defer C.free(unsafe.Pointer(cs))
+	return newValue(m.state, C._go_mrb_gv_get(m.state, C.mrb_intern_cstr(m.state, cs)))
+}
+
+// SetGlobalVariable sets the value of the global variable by the given name.
+func (m *Mrb) SetGlobalVariable(name string, value Value) {
+	cs := C.CString(name)
+	defer C.free(unsafe.Pointer(cs))
+
+	v := value.MrbValue(m)
+	C._go_mrb_gv_set(m.state, C.mrb_intern_cstr(m.state, cs), v.value)
+}
+
 // ArenaIndex represents the index into the arena portion of the GC.
 //
 // See ArenaSave for more information.

--- a/mruby_test.go
+++ b/mruby_test.go
@@ -303,6 +303,71 @@ func TestMrbGetArgs(t *testing.T) {
 	}
 }
 
+func TestMrbGlobalVariable(t *testing.T) {
+	const (
+		TestValue = "HELLO"
+	)
+	mrb := NewMrb()
+	defer mrb.Close()
+	if _, err := mrb.LoadString(fmt.Sprintf(`$a = "%s"`, TestValue)); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	value := mrb.GetGlobalVariable("$a")
+	if value.String() != TestValue {
+		t.Fatalf("wrong value for $a: expected '%s', found '%s'", TestValue, value.String())
+	}
+	mrb.SetGlobalVariable("$b", mrb.StringValue(TestValue))
+	value, err := mrb.LoadString(`$b`)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if value.String() != TestValue {
+		t.Fatalf("wrong value for $b: expected '%s', found '%s'", TestValue, value.String())
+	}
+}
+
+func TestMrbInstanceVariable(t *testing.T) {
+	const (
+		CockerSpaniel   = "cocker spaniel"
+		GoldenRetriever = "golden retriever"
+		Husky           = "Husky"
+	)
+	mrb := NewMrb()
+	defer mrb.Close()
+	_, err := mrb.LoadString(`
+		class Dog
+			def initialize(breed)
+				@breed = breed
+			end
+			def breed
+				"cocker spaniel" # this line exists to ensure that it's not invoking the accessor method
+			end
+			def real_breed
+				@breed
+			end
+		end
+	`)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	dogClass := mrb.Class("Dog", nil)
+	if dogClass == nil {
+		t.Fatalf("dog class not found")
+	}
+	inst, err := dogClass.New(mrb.StringValue(GoldenRetriever))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	value := inst.GetInstanceVariable("@breed")
+	if value.String() != GoldenRetriever {
+		t.Fatalf("wrong value for Dog.@breed. expected: '%s', found: '%s'", GoldenRetriever, value.String())
+	}
+	inst.SetInstanceVariable("@breed", mrb.StringValue(Husky))
+	value = inst.GetInstanceVariable("@breed")
+	if value.String() != Husky {
+		t.Fatalf("wrong value for Dog.@breed. expected: '%s', found: '%s'", Husky, value.String())
+	}
+}
 func TestMrbLoadString(t *testing.T) {
 	mrb := NewMrb()
 	defer mrb.Close()

--- a/mruby_test.go
+++ b/mruby_test.go
@@ -328,7 +328,6 @@ func TestMrbGlobalVariable(t *testing.T) {
 
 func TestMrbInstanceVariable(t *testing.T) {
 	const (
-		CockerSpaniel   = "cocker spaniel"
 		GoldenRetriever = "golden retriever"
 		Husky           = "Husky"
 	)

--- a/value.go
+++ b/value.go
@@ -41,6 +41,20 @@ func init() {
 	Nil = [0]byte{}
 }
 
+// SetInstanceVariable sets an instance variable on this value.
+func (v *MrbValue) SetInstanceVariable(variable string, value *MrbValue) {
+	cs := C.CString(variable)
+	defer C.free(unsafe.Pointer(cs))
+	C._go_mrb_iv_set(v.state, v.value, C.mrb_intern_cstr(v.state, cs), value.value)
+}
+
+// GetInstanceVariable gets an instance variable on this value.
+func (v *MrbValue) GetInstanceVariable(variable string) *MrbValue {
+	cs := C.CString(variable)
+	defer C.free(unsafe.Pointer(cs))
+	return newValue(v.state, C._go_mrb_iv_get(v.state, v.value, C.mrb_intern_cstr(v.state, cs)))
+}
+
 // Call calls a method with the given name and arguments on this
 // value.
 func (v *MrbValue) Call(method string, args ...Value) (*MrbValue, error) {

--- a/value.go
+++ b/value.go
@@ -41,6 +41,28 @@ func init() {
 	Nil = [0]byte{}
 }
 
+// CallInstanceMethod calls a method on the instance without a block
+func (v *MrbValue) CallInstanceMethod(method string, value []*MrbValue) *MrbValue {
+	cs := C.CString(method)
+	defer C.free(unsafe.Pointer(cs))
+	vals := make([]C.mrb_value, len(value))
+	for k, vv := range value {
+		vals[k] = vv.value
+	}
+	return newValue(v.state, C.mrb_funcall_argv(v.state, v.value, C.mrb_intern_cstr(v.state, cs), C.mrb_int(len(value)), &vals[0]))
+}
+
+// CallInstanceMethodBlock calls a method on the instance with a block
+func (v *MrbValue) CallInstanceMethodBlock(method string, value []*MrbValue, block *MrbValue) *MrbValue {
+	cs := C.CString(method)
+	defer C.free(unsafe.Pointer(cs))
+	vals := make([]C.mrb_value, len(value))
+	for k, vv := range value {
+		vals[k] = vv.value
+	}
+	return newValue(v.state, C.mrb_funcall_with_block(v.state, v.value, C.mrb_intern_cstr(v.state, cs), C.mrb_int(len(value)), &vals[0], block.value))
+}
+
 // SetInstanceVariable sets an instance variable on this value.
 func (v *MrbValue) SetInstanceVariable(variable string, value *MrbValue) {
 	cs := C.CString(variable)


### PR DESCRIPTION
Added *MrbValue.GetInstanceVariable, *MrbValue.SetInstanceVariable, *Mrb.GetGlobalVariable, *Mrb.SetGlobalVariable and their underlying C methods to allow Go to pass variables to/from Ruby.

This is honestly a staple of ANY scripting implementation. 