### PR TITLE
Fix build with MRuby 2.0.0

### DIFF
--- a/array.go
+++ b/array.go
@@ -1,6 +1,7 @@
 package mruby
 
 // #include "gomruby.h"
+// mrb_int _mrb_ary_len(mrb_value ary) { return RARRAY_LEN(ary); }
 import "C"
 
 // Array represents an MrbValue that is a Array in Ruby.
@@ -12,7 +13,7 @@ type Array struct {
 
 // Len returns the length of the array.
 func (v *Array) Len() int {
-	return int(C.mrb_ary_len(v.state, v.value))
+	return int(C._mrb_ary_len(v.value))
 }
 
 // Get gets an element form the Array by index.

--- a/array.go
+++ b/array.go
@@ -1,7 +1,6 @@
 package mruby
 
 // #include "gomruby.h"
-// mrb_int _mrb_ary_len(mrb_value ary) { return RARRAY_LEN(ary); }
 import "C"
 
 // Array represents an MrbValue that is a Array in Ruby.

--- a/func.go
+++ b/func.go
@@ -63,7 +63,7 @@ func goMRBFuncCall(s *C.mrb_state, v C.mrb_value) C.mrb_value {
 
 	// Lookup the class itself
 	classTable.Mutex.Lock()
-	methodTable := classTable.Map[ci.proc.target_class]
+	methodTable := classTable.Map[ci.target_class]
 	classTable.Mutex.Unlock()
 	if methodTable == nil {
 		panic(fmt.Sprintf("func call on unknown class"))

--- a/gomruby.h
+++ b/gomruby.h
@@ -268,4 +268,8 @@ static inline mrb_value _go_mrb_gv_get(mrb_state *m, mrb_sym sym) {
   return mrb_gv_get(m, sym);
 }
 
+static inline mrb_int _mrb_ary_len(mrb_value ary) {
+  return RARRAY_LEN(ary);
+}
+
 #endif

--- a/value.go
+++ b/value.go
@@ -139,7 +139,7 @@ func (v *MrbValue) GCProtect() {
 // when this value is a proc.
 func (v *MrbValue) SetProcTargetClass(c *Class) {
 	proc := C._go_mrb_proc_ptr(v.value)
-	proc.target_class = c.class
+	proc.e = *(*[8]byte)(unsafe.Pointer(&c.class))
 }
 
 // Type returns the ValueType of the MrbValue. See the constants table.


### PR DESCRIPTION
These changes should fix the build against MRuby 2.0.0. [#72]

The example code in the readme runs fine.

At least one test blows up with a stack corruption error so some additional fixes are needed. There may well be better ways to do this, the change in `value.go` is especially ugly but fixing this has already pushed my cgo to the limits so I can't do more I'm afraid. Hopefully this will help others to pick up the project and give it some more love.