### PR TITLE
Add new value type Symbol

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -498,7 +498,15 @@ func (d *decoder) decodeStruct(name string, v *MrbValue, result reflect.Value) e
 func decodeStructHashGetter(mrb *Mrb, h *Hash) decodeStructGetter {
 	return func(key string) (*MrbValue, error) {
 		rbKey := mrb.StringValue(key)
-		return h.Get(rbKey)
+		rbValue, err := h.Get(rbKey)
+		if err != nil {
+			return nil, err
+		}
+		if rbValue.Type() != TypeNil {
+			return rbValue, nil
+		}
+		rbSymbolKey := mrb.SymbolValue(key)
+		return h.Get(rbSymbolKey)
 	}
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -103,6 +103,16 @@ func TestDecode(t *testing.T) {
 			&outStructString,
 			structString{Foo: "bar"},
 		},
+		{
+			`{:foo => "bar"}`,
+			&outStructString,
+			structString{Foo: "bar"},
+		},
+		{
+			`{foo: "bar"}`,
+			&outStructString,
+			structString{Foo: "bar"},
+		},
 
 		// Struct from object with methods
 		{

--- a/hash_test.go
+++ b/hash_test.go
@@ -8,7 +8,7 @@ func TestHash(t *testing.T) {
 	mrb := NewMrb()
 	defer mrb.Close()
 
-	value, err := mrb.LoadString(`{"foo" => "bar", "baz" => false}`)
+	value, err := mrb.LoadString(`{"foo" => "bar", "baz" => false, :fizz => 1, buzz: 2.0}`)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -36,6 +36,30 @@ func TestHash(t *testing.T) {
 		t.Fatalf("bad: %s", value)
 	}
 
+	// Get fixnum type with symbol key
+	value, err = h.Get(Symbol("fizz"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if valType := value.Type(); valType != TypeFixnum {
+		t.Fatalf("bad type: %v", valType)
+	}
+	if value.Fixnum() != 1 {
+		t.Fatalf("bad: %s", value)
+	}
+
+	// Get float type with symbol key
+	value, err = h.Get(Symbol("buzz"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if valType := value.Type(); valType != TypeFloat {
+		t.Fatalf("bad type: %v", valType)
+	}
+	if value.Float() != 2.0 {
+		t.Fatalf("bad: %s", value)
+	}
+
 	// Set
 	err = h.Set(String("foo"), String("baz"))
 	if err != nil {
@@ -57,7 +81,7 @@ func TestHash(t *testing.T) {
 	if value.Type() != TypeArray {
 		t.Fatalf("bad: %v", value.Type())
 	}
-	if value.String() != `["foo", "baz"]` {
+	if value.String() != `["foo", "baz", :fizz, :buzz]` {
 		t.Fatalf("bad: %s", value)
 	}
 
@@ -74,7 +98,7 @@ func TestHash(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if value.String() != `["baz"]` {
+	if value.String() != `["baz", :fizz, :buzz]` {
 		t.Fatalf("bad: %s", value)
 	}
 

--- a/mruby.go
+++ b/mruby.go
@@ -388,6 +388,13 @@ func (m *Mrb) StringValue(s string) *MrbValue {
 	return newValue(m.state, C.mrb_str_new_cstr(m.state, cs))
 }
 
+// SymbolValue returns a Value for a symbol.
+func (m *Mrb) SymbolValue(s string) *MrbValue {
+	cs := C.CString(s)
+	defer C.free(unsafe.Pointer(cs))
+	return newValue(m.state, C.mrb_check_intern_cstr(m.state, cs))
+}
+
 func checkException(state *C.mrb_state) error {
 	if state.exc == nil {
 		return nil

--- a/value.go
+++ b/value.go
@@ -26,6 +26,9 @@ type NilType [0]byte
 // String is objects of the type String.
 type String string
 
+// Symbol is objects of the type Symbol.
+type Symbol string
+
 // Nil is a constant that can be used as a Nil Value
 var Nil NilType
 
@@ -241,6 +244,11 @@ func (NilType) MrbValue(m *Mrb) *MrbValue {
 // MrbValue returns the native MRB value
 func (s String) MrbValue(m *Mrb) *MrbValue {
 	return m.StringValue(string(s))
+}
+
+// MrbValue returns the native MRB value
+func (s Symbol) MrbValue(m *Mrb) *MrbValue {
+	return m.SymbolValue(string(s))
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Closes #56

This uses `C.mrb_check_intern_cstr ` instead of `C.mrb_intern_cstr` as the former returns an `mrb_value` while the latter returns an `mrb_sym` (which we don't want)

Also allows struct keys to be symbols, for example:

```go
type Food struct {
    Name string
    Description string
}
```

```rb
{:name => "aks-engine", :description => "Azure Kubernetes Engine"}
# or
{name: "aks-engine", description: "Azure Kubernetes Engine"}
```

Thanks for creating this useful library!