### PR TITLE
Allow struct fields to be optional

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -116,6 +116,8 @@ func (d *decoder) decodeBool(name string, v *MrbValue, result reflect.Value) err
 		result.Set(reflect.ValueOf(false))
 	case TypeTrue:
 		result.Set(reflect.ValueOf(true))
+	case TypeNil:
+		// Do nothing, but also don't return an error
 	default:
 		return fmt.Errorf("%s: unknown type %v", name, t)
 	}
@@ -127,6 +129,8 @@ func (d *decoder) decodeFloat(name string, v *MrbValue, result reflect.Value) er
 	switch t := v.Type(); t {
 	case TypeFloat:
 		result.Set(reflect.ValueOf(v.Float()))
+	case TypeNil:
+		// Do nothing, but also don't return an error
 	default:
 		return fmt.Errorf("%s: unknown type %v", name, t)
 	}
@@ -316,8 +320,12 @@ func (d *decoder) decodeSlice(name string, v *MrbValue, result reflect.Value) er
 
 	// Get the hash of the value
 	array := v.Array()
+	len := 0
+	if array.Type() != TypeNil {
+		len = array.Len()
+	}
 
-	for i := 0; i < array.Len(); i++ {
+	for i := 0; i < len; i++ {
 		// Get the key and value in Ruby. This should do no allocations.
 		rbVal, err := array.Get(i)
 		if err != nil {

--- a/decode.go
+++ b/decode.go
@@ -348,6 +348,8 @@ func (d *decoder) decodeString(name string, v *MrbValue, result reflect.Value) e
 			strconv.FormatInt(int64(v.Fixnum()), 10)).Convert(result.Type()))
 	case TypeString:
 		result.Set(reflect.ValueOf(v.String()).Convert(result.Type()))
+	case TypeNil:
+		// Do nothing, but also don't return an error
 	default:
 		return fmt.Errorf("%s: unknown type to string: %v", name, t)
 	}

--- a/decode.go
+++ b/decode.go
@@ -149,6 +149,8 @@ func (d *decoder) decodeInt(name string, v *MrbValue, result reflect.Value) erro
 		}
 
 		result.SetInt(int64(v))
+	case TypeNil:
+		// Do nothing, but also don't return an error
 	default:
 		return fmt.Errorf("%s: unknown type %v", name, t)
 	}
@@ -189,6 +191,8 @@ func (d *decoder) decodeInterface(name string, v *MrbValue, result reflect.Value
 		set = reflect.Indirect(reflect.New(reflect.TypeOf(result)))
 	case TypeString:
 		set = reflect.Indirect(reflect.New(reflect.TypeOf("")))
+	case TypeNil:
+		// Do nothing, but also don't return an error
 	default:
 		return fmt.Errorf(
 			"%s: cannot decode into interface: %v",
@@ -244,6 +248,12 @@ func (d *decoder) decodeMap(name string, v *MrbValue, result reflect.Value) erro
 
 	// Get the hash of the value
 	hash := v.Hash()
+	if hash.Type() == TypeNil {
+		// Set the empty map
+		set.Set(resultMap)
+		return nil
+	}
+
 	keysRaw, err := hash.Keys()
 	if err != nil {
 		return err

--- a/decode_test.go
+++ b/decode_test.go
@@ -99,6 +99,11 @@ func TestDecode(t *testing.T) {
 
 		// Struct from Hash
 		{
+			`{}`,
+			&outStructString,
+			structString{},
+		},
+		{
 			`{"foo" => "bar"}`,
 			&outStructString,
 			structString{Foo: "bar"},


### PR DESCRIPTION
For example this allows this:

```go
type Food struct {
    Name string
    Rig string
    Description string
}
```

to be decoded from this:

```rb
{"name" => "aks-engine", "description" => "Azure Kubernetes Engine"}
```

where the `Rig` field is optional and will not be set

Here's a more comprehensive test program: https://gist.github.com/SeekingMeaning/2e6260914391d2572f2a4bba22861d1e